### PR TITLE
Added support for ssh over sudo

### DIFF
--- a/avocado/utils/network/common.py
+++ b/avocado/utils/network/common.py
@@ -7,6 +7,4 @@ def run_command(command, host, sudo=False):
     if host.__class__.__name__ == 'LocalHost':
         return process.system_output(command, sudo=sudo).decode('utf-8')
 
-    if sudo:
-        command = "sudo {}".format(command)
-    return host.remote_session.cmd(command).stdout.decode('utf-8')
+    return host.remote_session.cmd(command, sudo=sudo).stdout.decode('utf-8')


### PR DESCRIPTION
This allows commands to be run over sudo in ssh without
configuring passwordless sudo or using the root account to ssh.
This also solves the issue where avocado fails to configure
net interfaces on a remote machine that uses password-based sudo.

Signed-off-by: Jacob Root <otis@otisroot.com>